### PR TITLE
Fix submit buttons so they have no data-disable-with attribute

### DIFF
--- a/lib/primer/rails_forms/acts_as_component.rb
+++ b/lib/primer/rails_forms/acts_as_component.rb
@@ -18,9 +18,11 @@ module Primer
 
         def before_render; end
 
+        # rubocop:disable Naming/AccessorMethodName
         def set_original_view_context(view_context)
           @view_context = view_context
         end
+        # rubocop:enable Naming/AccessorMethodName
       end
 
       def self.extended(base)

--- a/lib/primer/rails_forms/acts_as_component.rb
+++ b/lib/primer/rails_forms/acts_as_component.rb
@@ -17,6 +17,10 @@ module Primer
         end
 
         def before_render; end
+
+        def set_original_view_context(view_context)
+          @view_context = view_context
+        end
       end
 
       def self.extended(base)

--- a/lib/primer/rails_forms/context.rb
+++ b/lib/primer/rails_forms/context.rb
@@ -70,8 +70,11 @@ module Primer
       end
 
       def add_input_data(key, value)
-        @input_arguments[:data] ||= {}
-        @input_arguments[:data][key] = value
+        input_data[key] = value
+      end
+
+      def remove_input_data(key)
+        input_data.delete(key)
       end
 
       def merge_input_arguments!(arguments)
@@ -141,6 +144,10 @@ module Primer
       end
 
       private
+
+      def input_data
+        @input_arguments[:data] ||= {}
+      end
 
       def caption_template_name
         @caption_template_name ||= if input.respond_to?(:value)

--- a/lib/primer/rails_forms/submit_button.rb
+++ b/lib/primer/rails_forms/submit_button.rb
@@ -34,7 +34,7 @@ module Primer
         # Never disable submit buttons. This overrides the global
         # ActionView::Base.automatically_disable_submit_tag setting.
         # Disabling the submit button is not accessible.
-        @context.add_input_data(:disable_with, false)
+        @context.remove_input_data(:disable_with)
       end
 
       def input_arguments

--- a/test/forms_test.rb
+++ b/test/forms_test.rb
@@ -164,4 +164,11 @@ class FormsTest < ActiveSupport::TestCase
 
     assert_selector "button[type=submit]"
   end
+
+  test "renders a submit button without data-disable-with" do
+    render_preview :submit_button_form
+
+    button = page.find_css("button[type=submit]").first
+    assert_nil button.attributes["data-disable-with"]
+  end
 end


### PR DESCRIPTION
Currently, submit buttons will have a `data-disable-with="false"` attribute set on them automatically, which makes the submit button say "false" when clicked. My intent was to remove `data-disable-with` entirely, but I forgot to test it before shipping 🤦 