### PR TITLE
Fix invalid handling of system arguments resulting in incorrect field names for activemodels

### DIFF
--- a/lib/primer/rails_forms/dsl/check_box_input.rb
+++ b/lib/primer/rails_forms/dsl/check_box_input.rb
@@ -4,12 +4,13 @@ module Primer
   module RailsForms
     module Dsl
       class CheckBoxInput < Input
-        attr_reader :name, :label, :system_arguments
+        attr_reader :name, :label
 
-        def initialize_input(name:, label:, **system_arguments)
+        def initialize(name:, label:, **system_arguments)
           @name = name
           @label = label
-          @system_arguments = system_arguments
+
+          super(**system_arguments)
         end
 
         def to_component

--- a/lib/primer/rails_forms/dsl/form_reference_input.rb
+++ b/lib/primer/rails_forms/dsl/form_reference_input.rb
@@ -6,10 +6,12 @@ module Primer
       class FormReferenceInput < Input
         attr_reader :ref_block, :fields_for_args, :fields_for_kwargs
 
-        def initialize_input(*fields_for_args, **fields_for_kwargs, &block)
+        def initialize(*fields_for_args, builder:, form:, **fields_for_kwargs, &block)
           @fields_for_args = fields_for_args
           @fields_for_kwargs = fields_for_kwargs
           @ref_block = block
+
+          super(builder: builder, form: form, **fields_for_kwargs)
         end
 
         def to_component

--- a/lib/primer/rails_forms/dsl/hidden_input.rb
+++ b/lib/primer/rails_forms/dsl/hidden_input.rb
@@ -6,9 +6,9 @@ module Primer
       class HiddenInput < Input
         attr_reader :name
 
-        def initialize_input(name:, **system_arguments)
+        def initialize(name:, **system_arguments)
           @name = name
-          @system_arguments = system_arguments
+          super(**system_arguments)
         end
 
         def to_component

--- a/lib/primer/rails_forms/dsl/input.rb
+++ b/lib/primer/rails_forms/dsl/input.rb
@@ -10,11 +10,9 @@ module Primer
 
         attr_reader :builder, :form, :input_arguments, :label_arguments, :caption, :validation_message, :ids
 
-        def initialize(*args, builder:, form:, **system_arguments, &block)
+        def initialize(builder:, form:, **system_arguments, &block)
           @builder = builder
           @form = form
-
-          initialize_input(*args, **system_arguments, &block)
 
           @input_arguments = system_arguments
 
@@ -47,8 +45,6 @@ module Primer
           add_input_aria(:required, true) if required?
           add_input_aria(:describedby, ids.values) if ids.any?
         end
-
-        def initialize_input; end
 
         def add_input_classes(*class_names)
           input_arguments[:class] = class_names(
@@ -153,10 +149,6 @@ module Primer
         end
 
         def type
-          raise_for_abstract_method!(__method__)
-        end
-
-        def system_arguments
           raise_for_abstract_method!(__method__)
         end
 

--- a/lib/primer/rails_forms/dsl/input.rb
+++ b/lib/primer/rails_forms/dsl/input.rb
@@ -10,7 +10,7 @@ module Primer
 
         attr_reader :builder, :form, :input_arguments, :label_arguments, :caption, :validation_message, :ids
 
-        def initialize(builder:, form:, **system_arguments, &block)
+        def initialize(builder:, form:, **system_arguments)
           @builder = builder
           @form = form
 

--- a/lib/primer/rails_forms/dsl/multi_input.rb
+++ b/lib/primer/rails_forms/dsl/multi_input.rb
@@ -6,12 +6,13 @@ module Primer
       class MultiInput < Input
         include InputMethods
 
-        attr_reader :name, :label, :system_arguments
+        attr_reader :name, :label
 
-        def initialize_input(name:, label:, **system_arguments)
+        def initialize(name:, label:, **system_arguments)
           @name = name
           @label = label
-          @system_arguments = system_arguments
+
+          super(**system_arguments)
 
           yield(self) if block_given?
         end

--- a/lib/primer/rails_forms/dsl/radio_button_group_input.rb
+++ b/lib/primer/rails_forms/dsl/radio_button_group_input.rb
@@ -4,12 +4,13 @@ module Primer
   module RailsForms
     module Dsl
       class RadioButtonGroupInput < Input
-        attr_reader :name, :system_arguments, :radio_buttons
+        attr_reader :name, :radio_buttons
 
-        def initialize_input(name:, **system_arguments)
+        def initialize(name:, **system_arguments)
           @name = name
-          @system_arguments = system_arguments
           @radio_buttons = []
+
+          super(**system_arguments)
 
           yield(self) if block_given?
         end

--- a/lib/primer/rails_forms/dsl/radio_button_input.rb
+++ b/lib/primer/rails_forms/dsl/radio_button_input.rb
@@ -4,13 +4,14 @@ module Primer
   module RailsForms
     module Dsl
       class RadioButtonInput < Input
-        attr_reader :name, :value, :label, :nested_form_block, :nested_form_arguments, :system_arguments
+        attr_reader :name, :value, :label, :nested_form_block, :nested_form_arguments
 
-        def initialize_input(name:, value:, label:, **system_arguments)
+        def initialize(name:, value:, label:, **system_arguments)
           @name = name
           @value = value
           @label = label
-          @system_arguments = system_arguments
+
+          super(**system_arguments)
 
           yield(self) if block_given?
         end

--- a/lib/primer/rails_forms/dsl/select_list_input.rb
+++ b/lib/primer/rails_forms/dsl/select_list_input.rb
@@ -14,13 +14,14 @@ module Primer
           end
         end
 
-        attr_reader :name, :label, :options, :system_arguments
+        attr_reader :name, :label, :options
 
-        def initialize_input(name:, label:, **system_arguments)
+        def initialize(name:, label:, **system_arguments)
           @name = name
           @label = label
           @options = []
-          @system_arguments = system_arguments
+
+          super(**system_arguments)
 
           yield(self) if block_given?
         end

--- a/lib/primer/rails_forms/dsl/submit_button_input.rb
+++ b/lib/primer/rails_forms/dsl/submit_button_input.rb
@@ -4,13 +4,14 @@ module Primer
   module RailsForms
     module Dsl
       class SubmitButtonInput < Input
-        attr_reader :name, :label, :system_arguments, :block
+        attr_reader :name, :label, :block
 
-        def initialize_input(name:, label:, **system_arguments, &block)
+        def initialize(name:, label:, **system_arguments, &block)
           @name = name
           @label = label
-          @system_arguments = system_arguments
           @block = block
+
+          super(**system_arguments)
         end
 
         def to_component

--- a/lib/primer/rails_forms/dsl/text_area_input.rb
+++ b/lib/primer/rails_forms/dsl/text_area_input.rb
@@ -4,12 +4,13 @@ module Primer
   module RailsForms
     module Dsl
       class TextAreaInput < Input
-        attr_reader :name, :label, :system_arguments
+        attr_reader :name, :label
 
-        def initialize_input(name:, label:, **system_arguments)
+        def initialize(name:, label:, **system_arguments)
           @name = name
           @label = label
-          @system_arguments = system_arguments
+
+          super(**system_arguments)
         end
 
         def to_component

--- a/lib/primer/rails_forms/dsl/text_field_input.rb
+++ b/lib/primer/rails_forms/dsl/text_field_input.rb
@@ -4,12 +4,13 @@ module Primer
   module RailsForms
     module Dsl
       class TextFieldInput < Input
-        attr_reader :name, :label, :system_arguments
+        attr_reader :name, :label
 
-        def initialize_input(name:, label:, **system_arguments)
+        def initialize(name:, label:, **system_arguments)
           @name = name
           @label = label
-          @system_arguments = system_arguments
+
+          super(**system_arguments)
         end
 
         def to_component

--- a/test/forms_test.rb
+++ b/test/forms_test.rb
@@ -79,6 +79,19 @@ class FormsTest < ActiveSupport::TestCase
     end
   end
 
+  test "names inputs correctly when rendered against an activemodel" do
+    model = DeepThought.new(42)
+
+    render_in_view_context do
+      form_with(model: model, url: "/foo", skip_default_ids: false) do |f|
+        render(SingleTextFieldForm.new(f))
+      end
+    end
+
+    text_field = page.find_css("input[type=text]").first
+    assert_equal text_field.attribute("name").value, "forms_test_deep_thought[ultimate_answer]"
+  end
+
   test "the input is described by the validation message" do
     model = DeepThought.new(41)
     model.valid? # populate validation error messages


### PR DESCRIPTION
Any form rendered inside a `form_with(model: <object>)` currently results in inputs with incorrect `name=` attributes. Consider this example:

```ruby
class MyForm < Primer::RailsForms::Base
  form do |frm|
    frm.text_field(name: :foo, label: "Foo")
  end
end

form_with(model: model) do |f|
  render MyForm.new(f)
end
```

The `foo` text field currently renders with `name="foo"` instead of `name="model[foo]"`