### PR TITLE
Support label arguments for radio button and check box groups

### DIFF
--- a/lib/primer/rails_forms/check_box_group.html.erb
+++ b/lib/primer/rails_forms/check_box_group.html.erb
@@ -1,6 +1,8 @@
 <fieldset>
   <% if @input.label %>
-    <legend class="FormControl-label mb-2"><%= @input.label %></legend>
+    <%= content_tag(:legend, **@input.label_arguments) do %>
+      <%= @input.label %>
+    <% end %>
   <% end %>
   <%= render(SpacingWrapper.new) do %>
     <% @input.check_boxes.each do |check_box| %>

--- a/lib/primer/rails_forms/dsl/check_box_group_input.rb
+++ b/lib/primer/rails_forms/dsl/check_box_group_input.rb
@@ -12,6 +12,8 @@ module Primer
 
           super(**system_arguments)
 
+          add_label_classes("FormControl-label", "mb-2")
+
           yield(self) if block_given?
         end
 

--- a/lib/primer/rails_forms/dsl/radio_button_group_input.rb
+++ b/lib/primer/rails_forms/dsl/radio_button_group_input.rb
@@ -13,6 +13,8 @@ module Primer
 
           super(**system_arguments)
 
+          add_label_classes("FormControl-label", "mb-2")
+
           yield(self) if block_given?
         end
 

--- a/lib/primer/rails_forms/radio_button_group.html.erb
+++ b/lib/primer/rails_forms/radio_button_group.html.erb
@@ -1,6 +1,8 @@
 <fieldset>
   <% if @input.label %>
-    <legend class="FormControl-label mb-2"><%= @input.label %></legend>
+    <%= content_tag(:legend, **@input.label_arguments) do %>
+      <%= @input.label %>
+    <% end %>
   <% end %>
   <%= render(SpacingWrapper.new) do %>
     <% @input.radio_buttons.each do |radio_button| %>


### PR DESCRIPTION
Any input wrapped with `FormControl` automatically accepts `label_arguments`, but radio button and check box groups don't use `FormControl`. This PR applies `label_arguments` to the `<legend>` element to allow for custom styling, etc.